### PR TITLE
feat: support Home and End key navigation in Tabs component

### DIFF
--- a/packages/react-tabs/package.json
+++ b/packages/react-tabs/package.json
@@ -13,6 +13,9 @@
     "type": "git",
     "url": "https://github.com/Abinesh-joyel/glide-ui/tree/master/packages/react-tabs"
   },
+  "bugs": {
+    "url": "https://github.com/Abinesh-joyel/glide-ui/issues"
+  },
   "keywords": [
     "react",
     "tabs",

--- a/packages/react-tabs/src/hooks/useKeyBoardEvent.tsx
+++ b/packages/react-tabs/src/hooks/useKeyBoardEvent.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React from 'react';
 
 interface KeyboardEvent {
   handleKeyDown: (event: React.KeyboardEvent) => void;
@@ -28,16 +28,24 @@ export default function usekeyBoardEvent(
   };
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
-    console.log("event", event);
+    console.log('event', event);
 
     switch (event.key) {
-      case "ArrowLeft":
+      case 'ArrowLeft':
         event.preventDefault();
         onPrevTab();
         break;
-      case "ArrowRight":
+      case 'ArrowRight':
         event.preventDefault();
         onNextTab();
+        break;
+      case 'Home':
+        event.preventDefault();
+        onChange(0);
+        break;
+      case 'End':
+        event.preventDefault();
+        onChange(total - 1);
         break;
       default:
         break;

--- a/packages/react-tabs/vite.config.ts
+++ b/packages/react-tabs/vite.config.ts
@@ -35,7 +35,12 @@ export default defineConfig({
     dts({
       insertTypesEntry: true,
       include: ['src'],
-      exclude: ['src/App.tsx', 'src/main.tsx', 'src/setupTests.ts'],
+      exclude: [
+        'src/App.tsx',
+        'src/main.tsx',
+        'src/setupTests.ts',
+        'src/__tests__',
+      ],
       rollupTypes: false,
     }),
   ],


### PR DESCRIPTION
According to the [WAI-ARIA Tabs design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/examples/tabs-automatic/)

- **Home key** → moves focus to the **first tab**
- **End key** → moves focus to the **last tab**